### PR TITLE
Add Dockerfile for League-Prod-Toolkit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+docs
+.vscode
+.hooks
+.github
+Architecture.drawio
+Architecture.png
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:16
+
+WORKDIR /app
+
+ADD . .
+
+RUN npm install
+
+RUN npm install -g typescript webpack webpack-cli
+
+RUN npx tsc && webpack
+
+RUN npm run build:modules
+
+RUN npm run postbuild
+
+RUN node ./dist/scripts/install.js -plugins theme-default
+
+COPY modules/plugin-config/config.dist.json modules/plugin-config/config.json
+
+# Cleanup to minimize size. Did not work for some reason, but leaving in incase
+RUN rm -rf Dockerfile auth.bat core frontend install.bat riot-api-key.bat start.bat nodemon.json scripts tsconfig.json types util webpack.config.js
+
+VOLUME /app/modules
+
+#Expose 3003 Port
+EXPOSE 3003
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Dockerfile support for the Web App.

I do not have experience with setting up Github actions, but I would like to set that up for building the Image automatically on new releases.

The Docker Image contains all the modules installed by default. I can understand that this is probably not the smartest, but from testing it was the best as it allowed for quicker initial setup, and less problems.

Docker Image avaliable on my personal account. This is something I would prefer by moved to an "official" RCVolus docker account: https://hub.docker.com/r/eirikskarding/leagueprodtoolkit